### PR TITLE
修复：新版本的Swoole的Swoole Table Key过长导致报错

### DIFF
--- a/src/Plumber.php
+++ b/src/Plumber.php
@@ -355,7 +355,7 @@ class Plumber
     private function createWorkerRecreateLimiter()
     {
         $name = sprintf(
-            'plumber:%s:rate_limiter:worker_recreate',
+            'plumber:%s',
             isset($this->options['app_name']) ? $this->options['app_name'] : ''
         );
 


### PR DESCRIPTION
报错：
`Uncaught Exception Symfony\Component\ErrorHandler\Error\FatalError: "Error: Uncaught ErrorException: Warning: Swoole\Table::set(): key[rate-limit:plumber:CloudAdminPlumber:rate_limiter:worker_recreate:0] is too long in /***/vendor/codeages/plumber2/src/SwooleTableRateLimiterStorage.php:38 Stack trace: 
#0 /***/vendor/codeages/rate-limiter/src/RateLimiter.php(46): Codeages\Plumber\SwooleTableRateLimiterStorage->set('rate-limit:plum...', '10, 1658283410', 60) 
#1 /***/vendor/codeages/rate-limiter/src/RateLimiter.php(59): Codeages\RateLimiter\RateLimiter->check(0, 0) 
#2 /***/vendor/codeages/rate-limiter/src/RateLimiter.php(93): Codeages\RateLimiter\RateLimiter->getAllowance(0) 
#3 /***/vendor/codeages/plumber2/src/Plumber.php(137): Codeages\RateLimiter\RateLimiter->getAllow(0) 
#4 [internal function]: Codeages\Plumber\Plumber->Codeages\Plumber\{closure}(Object(Swoole\Process\Pool), 0) 
#5 /***/vendor/codeages/plumbe" at /***/vendor/codeages/plumber2/src/SwooleTableRateLimiterStorage.php line 38 `

环境：
swoole：Version => 4.8.8

修复原因：

1. swoole版本大于4.4，swoole文档上面有些key不得超过63个字节。
2. 修改宏开关设置 swoole_config.h 需要重新编译。
3. 不建议设置过大Key，没有实际用处而且会浪费很多内存。
4. 如key中的rate_limiter，已会在RateLimiter中包含，不需要额外声明。

参考：
http://errornoerror.com/question/12047327774249692469/